### PR TITLE
Adjust run_test rules for Windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -96,10 +96,14 @@ class NinjaFile(object):
     def add_run_test_builds(self):
         # For everything that gets installed to build/unittests, add a rule for +basename
         # that runs the test from its original location.
+        unittest_dir = 'build/unittests/'
+        if self.globalEnv.TargetOSIs('windows'):
+            unittest_dir = unittest_dir.replace("/", "\\")
+
         tests = [flatten(build['inputs'])[0]
                  for build in self.builds
                  if build['rule'] == 'INSTALL'
-                 and flatten(build['outputs'])[0].startswith('build/unittests/')]
+                 and flatten(build['outputs'])[0].startswith(unittest_dir)]
         self.builds += [dict(outputs='+'+os.path.basename(test), inputs=test, rule='RUN_TEST')
                         for test in tests]
 

--- a/build.py
+++ b/build.py
@@ -96,14 +96,10 @@ class NinjaFile(object):
     def add_run_test_builds(self):
         # For everything that gets installed to build/unittests, add a rule for +basename
         # that runs the test from its original location.
-        unittest_dir = 'build/unittests/'
-        if self.globalEnv.TargetOSIs('windows'):
-            unittest_dir = unittest_dir.replace("/", "\\")
-
         tests = [flatten(build['inputs'])[0]
                  for build in self.builds
                  if build['rule'] == 'INSTALL'
-                 and flatten(build['outputs'])[0].startswith(unittest_dir)]
+                 and flatten(build['outputs'])[0].startswith(os.path.join('build', 'unittests'))]
         self.builds += [dict(outputs='+'+os.path.basename(test), inputs=test, rule='RUN_TEST')
                         for test in tests]
 


### PR DESCRIPTION
To fix enables the `+unitest_test.exe` on Windows. On Windows, paths are "build\unittests" instead of "build/unittests".

I used `string.replace()` instead of `os.path.normpath()` since the later will remove the trailing slash.