### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Fix line endings on shell scripts
+icecream/* text eol=lf


### PR DESCRIPTION
bash scripts are required to have lf line endings instead of crlf.
This ensures that these scripts are checked out with lf endings
regardless of git autocrlf settings.