### PR TITLE
Precompiled header support

### DIFF
--- a/pch.h
+++ b/pch.h
@@ -1,0 +1,14 @@
+#include "mongo/config.h"
+
+// XXX this is needed for secure_zero_memory.cpp on OSX. Decide if we'd rather do this or opt-out of
+// PCH for some files.
+#if defined(MONGO_CONFIG_HAVE_MEMSET_S)
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
+
+#include "mongo/platform/basic.h"
+
+#include <memory>
+#include <string>
+
+#include "mongo/db/jsobj.h"

--- a/test-pch.h
+++ b/test-pch.h
@@ -1,0 +1,8 @@
+#include "mongo/platform/basic.h"
+
+#include <memory>
+#include <string>
+
+#include "mongo/db/jsobj.h"
+#include "mongo/stdx/functional.h"
+#include "mongo/unittest/unittest.h"


### PR DESCRIPTION
This adds pch support. It is opt-in with the flag `--pch` and incompatible with `--icrecream`.

Tested on Windows

This is based on 87cb2cef2a887976c4043957ae3d6abeba648250