### PR TITLE
Better reporting in the cases where a tool is missing

### DIFF
--- a/build.py
+++ b/build.py
@@ -618,7 +618,7 @@ class NinjaFile(object):
             outputs=targets[0],
             implicit_outputs=targets[1:],
             inputs=strmap(sources),
-            implicit=implicit_deps + libdeps + toolPath,
+            implicit=implicit_deps + libdeps + [toolPath],
             order_only=['_generated_headers']
                        if tool in ('CC', 'CXX', 'SHCC', 'SHCXX', 'RC')
                        else [],

--- a/build.py
+++ b/build.py
@@ -610,12 +610,15 @@ class NinjaFile(object):
         # I don't think the tradeoff is worth it.
         # For more details see: https://github.com/ninja-build/ninja/issues/1184
         targets = [t for t in strmap(targets) if not t.endswith('.dwo')]
+        toolPath = myEnv.WhereIs('$'+tool)
+        assert toolPath is not None, 'Unable to find the location of tool \'%s\'' % tool
+
         self.builds.append(dict(
             rule=tool,
             outputs=targets[0],
             implicit_outputs=targets[1:],
             inputs=strmap(sources),
-            implicit=implicit_deps + libdeps + [myEnv.WhereIs('$'+tool)],
+            implicit=implicit_deps + libdeps + toolPath,
             order_only=['_generated_headers']
                        if tool in ('CC', 'CXX', 'SHCC', 'SHCXX', 'RC')
                        else [],


### PR DESCRIPTION
After I installed VS 2017 the RC tool could not be found and it took me a while to figure out that was the case, because it was being reported as 'None' in the 'implicit' list, so I was only getting this message:
`scons: *** [build.ninja] AttributeError : 'NoneType' object has no attribute 'replace'
Traceback (most recent call last):
  File "E:\workspace\mongo\src\third_party\scons-2.5.0\scons-local-2.5.0\SCons\Action.py", line 1054, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "src/mongo/db/modules\ninja\build.py", line 58, in makeNinjaFile
    ninja_file.write()
  File "src/mongo/db/modules\ninja\build.py", line 642, in write
    self.write_builds(ninja)
  File "src/mongo/db/modules\ninja\build.py", line 858, in write_builds
    ninja.build(**build)
  File "src/mongo/db/modules\ninja\ninja_syntax.py", line 69, in build
    implicit = [escape_path(x) for x in as_list(implicit)]
  File "src/mongo/db/modules\ninja\ninja_syntax.py", line 14, in escape_path
    return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')
AttributeError: 'NoneType' object has no attribute 'replace'
scons: building terminated because of errors.
build.ninja failed: AttributeError : 'NoneType' object has no attribute 'replace'`

With this change it will produce a more informative error message:
`Failed on node: build\ninja\mongo\db\db.res
Command: $RC $_CPPDEFFLAGS $_CPPINCFLAGS $RCFLAGS /fo$TARGET $SOURCES

scons: *** [build.ninja] AssertionError : Unable to find the location of tool 'RC'
Traceback (most recent call last):
  File "E:\workspace\mongo\src\third_party\scons-2.5.0\scons-local-2.5.0\SCons\Action.py", line 1054, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "src/mongo/db/modules\ninja\build.py", line 57, in makeNinjaFile
    ninja_file = NinjaFile(str(target[0]), env)
  File "src/mongo/db/modules\ninja\build.py", line 100, in __init__
    self.find_build_nodes()
  File "src/mongo/db/modules\ninja\build.py", line 300, in find_build_nodes
    self.handle_build_node(n)
  File "src/mongo/db/modules\ninja\build.py", line 614, in handle_build_node
    assert toolPath is not None, 'Unable to find the location of tool \'%s\'' % tool
AssertionError: Unable to find the location of tool 'RC'
scons: building terminated because of errors.
build.ninja failed: AssertionError : Unable to find the location of tool 'RC'`