### PR TITLE
Quote commands executed through cmd.exe

### DIFF
--- a/build.py
+++ b/build.py
@@ -76,7 +76,7 @@ def where_is(env, exe):
             path = '/usr/lib/icecream/bin/'+exe
 
     # Normalize missing to '' rather than None
-    return path if path else ''
+    return ('"' + path + '"') if path else ''
 
 def strmap(list):
     for node in list:


### PR DESCRIPTION
Without this change, if ninja.exe is in a directory whose name contains spaces, the following error occurs:
`E:\workspace\mongo>ninja compiledb
[1/1] COMPILE_DB compile_commands.json
FAILED: compile_commands.json
cmd /c C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.EXE -f build.ninja -t compdb CXX CC SHCXX SHCC > compile_commands.json.tmp && move /y compile_commands.json.tmp compile_commands.json
'C:\Program' is not recognized as an internal or external command, operable program or batch file.
ninja: build stopped: subcommand failed.`