### PR TITLE
Manage IDL dependencies as deps instead of with the scons scanners

### DIFF
--- a/build.py
+++ b/build.py
@@ -571,6 +571,7 @@ class NinjaFile(object):
                 ))
             return
         elif tool not in ('$CC', '$CXX', '$SHCC', '$SHCXX', '$LINK', '$SHLINK', '$AR', '$RC'):
+            n.scan() # We need this for IDL.
             implicit_deps += strmap(n.implicit)
             self.builds.append(dict(
                 rule='EXEC',


### PR DESCRIPTION
This allows means that ninja file generation does less work and all
the IDL work to actual build time.