### PR TITLE
Use short-form -p of ccache --print-config for compatibility with 3.7

### DIFF
--- a/build.py
+++ b/build.py
@@ -1219,7 +1219,7 @@ def configure(conf, env):
                 # AddToCCFLAGSIfSupported but that is available to modules.
                 env.Append(CCFLAGS=["-Qunused-arguments"])
 
-            settings = (subprocess.check_output([env['_NINJA_CCACHE'], '--print-config'])
+            settings = (subprocess.check_output([env['_NINJA_CCACHE'], '-p'])
                             .decode('utf8'))
             if 'max_size = 5.0G' in settings:
                 print('*** ccache is using the default 5GB cache size. You can raise it by running:')


### PR DESCRIPTION
ccache 3.7 renames --print-config, which we use to check the disk space
allocated to the cache, as --show-config. Use the short-form -p switch
instead, which is consistent across 3.7 and previous releases.