### PR TITLE
Make all .h files pass lint checks.

### DIFF
--- a/pch.h
+++ b/pch.h
@@ -1,7 +1,8 @@
+//    Copyright (C) 2019-present MongoDB, Inc.
 #include "mongo/config.h"
 
-// XXX this is needed for secure_zero_memory.cpp on OSX. Decide if we'd rather do this or opt-out of
-// PCH for some files.
+// XXX this is needed for secure_zero_memory.cpp on OSX. Decide if we'd rather
+// do this or opt-out of PCH for some files.
 #if defined(MONGO_CONFIG_HAVE_MEMSET_S)
 #define __STDC_WANT_LIB_EXT1__ 1
 #endif

--- a/test-pch.h
+++ b/test-pch.h
@@ -1,3 +1,4 @@
+//    Copyright (C) 2019-present MongoDB, Inc.
 #include "mongo/platform/basic.h"
 
 #include <memory>


### PR DESCRIPTION
This allows a user to run lint.py successfully with the ninja module present in their source tree.