### PR TITLE
Darwin - Check ethernet speed and whitelist another adapter

### DIFF
--- a/darwin/verify_icecream.py
+++ b/darwin/verify_icecream.py
@@ -12,12 +12,6 @@ import string
 import subprocess
 import sys
 
-ETHERNET_ADAPTERS = [
-    "Thunderbolt Ethernet", # Non USB-C Apple laptops
-    "USB 10/100/1000 LAN",  # USB-C Apple laptops
-    "Belkin USB-C LAN",     # USB-C Apple laptops
-]
-
 def exit_with_error(err_str):
     """print error in red and exit."""
     print("\033[91mERROR: %s\033[0m" % (err_str))
@@ -37,41 +31,16 @@ def print_ok(err_str):
 def verify_icecream():
     """Do verification"""
 
-    # Step 1 - Check for ethernet
-    ethernet_ports_str = subprocess.check_output(["networksetup", "listallhardwareports"]).decode('utf-8')
-    ethernet_ports = ethernet_ports_str.splitlines()
-    port_count = int((ethernet_ports.index('VLAN Configurations') - 1) / 4)
-    found_ethernet = False
-    for i in range(port_count):
-        base = i * 4
-        hw_port = ethernet_ports[base + 1]
-        device = ethernet_ports[base + 2]
-        eth_address = ethernet_ports[base + 3]
-        device = device.replace("Device: ", "")
+    # Step 1 - Check ifconfig for a wired 1 gigabit connection
+    ifconfig_str = subprocess.check_output(["ifconfig", "-u"]).decode('utf-8')
 
-        #print ("%s - %s - %s" % (hw_port, device, eth_address))
-
-        # Well known adaptors
-        if not [ether for ether in ETHERNET_ADAPTERS if ether in hw_port]:
-            continue
-
-        ifconfig = subprocess.check_output(["ifconfig", device]).decode('utf-8')
-
-        # There is always a space after "inet". We check that the device gets an address
-        # We don't check the routing rules since mac promotes the wired device over wifi
-        if not("inet " in ifconfig and "inet6" in ifconfig):
-            continue
-
-        # Now check for speed in case of bad physical ports
-        if not("1000baseT" in ifconfig):
-            print_warning(
+    if "100baseT" in ifconfig_str:
+        print_warning(
 """Wired ethernet connection is too slow. Icecream requires a 1 Gigabit
 ethernet connection to perform well. Verify the wired connection is 1 Gigabit
 via "ifconfig", verify the quality of the ethernet cable, and ethernet jack.""")
 
-        found_ethernet = True
-
-    if not found_ethernet:
+    if not("1000baseT" in ifconfig_str):
         print_warning(
 """No wired ethernet connection found. Icecream only works with on a
 wired network. Make sure a ethernet adaptor is connected. See "Network"

--- a/darwin/verify_icecream.py
+++ b/darwin/verify_icecream.py
@@ -12,6 +12,12 @@ import string
 import subprocess
 import sys
 
+ETHERNET_ADAPTERS = [
+    "Thunderbolt Ethernet", # Non USB-C Apple laptops
+    "USB 10/100/1000 LAN",  # USB-C Apple laptops
+    "Belkin USB-C LAN",     # USB-C Apple laptops
+]
+
 def exit_with_error(err_str):
     """print error in red and exit."""
     print("\033[91mERROR: %s\033[0m" % (err_str))
@@ -46,8 +52,7 @@ def verify_icecream():
         #print ("%s - %s - %s" % (hw_port, device, eth_address))
 
         # Well known adaptors
-        # May be nice to check for speed
-        if not("Thunderbolt Ethernet" in hw_port or "USB 10/100/1000 LAN" in hw_port):
+        if not [ether for ether in ETHERNET_ADAPTERS if ether in hw_port]:
             continue
 
         ifconfig = subprocess.check_output(["ifconfig", device]).decode('utf-8')
@@ -56,6 +61,13 @@ def verify_icecream():
         # We don't check the routing rules since mac promotes the wired device over wifi
         if not("inet " in ifconfig and "inet6" in ifconfig):
             continue
+
+        # Now check for speed in case of bad physical ports
+        if not("1000baseT" in ifconfig):
+            print_warning(
+"""Wired ethernet connection is too slow. Icecream requires a 1 Gigabit
+ethernet connection to perform well. Verify the wired connection is 1 Gigabit
+via "ifconfig", verify the quality of the ethernet cable, and ethernet jack.""")
 
         found_ethernet = True
 


### PR DESCRIPTION
1. Check the user has a 1 gigabit connection.
2. Add another adapter to the whitelist. The interns get "USB 10/100/1000 LAN" but other employees have other devices.