### PR TITLE
Adding shortcuts for unit test files

### DIFF
--- a/build.py
+++ b/build.py
@@ -857,11 +857,17 @@ class NinjaFile(object):
                 # Add shortcuts for this unit test.
                 for unit_test_source_file in \
                         n.executor.get_all_children()[0].executor.get_all_sources():
-                    pos_last_slash = str(unit_test_source_file).rfind('/')
-                    stripped_name = str(unit_test_source_file)[pos_last_slash + 1:-2]
+                    # Get the file name
+                    pos_last_slash = str(unit_test_source_file).rfind(os.path.sep)
+                    # Strip the '.o' or '.obj'
+                    stripped_name = str(unit_test_source_file)[pos_last_slash + 1:]
+                    pos_last_dot = stripped_name.find(".")
+                    stripped_name = stripped_name[:pos_last_dot]
 
                     if "_test" in stripped_name[len(stripped_name) - 5:]:
-                        stripped_name = '+' + stripped_name
+                        # Add suffix to tests on Windows to match other unit tests
+                        suffix = ".exe" if self.globalEnv.TargetOSIs('windows') else ""
+                        stripped_name = '+' + stripped_name + suffix
                         if (stripped_name not in self.unittest_shortcuts and stripped_name not
                                 in self.unittest_skipped_shortcuts):
                             # Add a shortcut for the given unit test file name.

--- a/build.py
+++ b/build.py
@@ -872,7 +872,7 @@ class NinjaFile(object):
                         elif test_file_name in self.unittest_shortcuts:
                             # There are multiple unit tests with the same file name. So we cannot
                             # create a shortcut for this test name.
-                            print('*** Duplicate test file name detected. No alias has been created for it, recommend renaming:', test_file_name)
+                            print('*** Duplicate test file name detected. No alias has been created for it, recommend renaming:', test_file_name[1:] + '.cpp')
                             del self.unittest_shortcuts[test_file_name]
                             self.unittest_skipped_shortcuts.add(test_file_name)
 

--- a/build.py
+++ b/build.py
@@ -16,8 +16,7 @@ import requests
 import subprocess
 import multiprocessing
 from buildscripts import errorcodes
-from os.path import basename
-from os.path import splitext
+from os.path import basename, splitext
 
 
 my_dir = os.path.dirname(__file__)
@@ -858,7 +857,7 @@ class NinjaFile(object):
                         n.executor.get_all_children()[0].executor.get_all_sources():
                     test_file_name = splitext(basename(str(unit_test_source_file)))[0]
 
-                    if "_test" in test_file_name[len(test_file_name) - 5:]:
+                    if "_test" in test_file_name:
                         # Add suffix to tests on Windows to match other unit tests
                         suffix = ".exe" if self.globalEnv.TargetOSIs('windows') else ""
                         test_file_name = '+' + test_file_name + suffix
@@ -873,6 +872,7 @@ class NinjaFile(object):
                         elif test_file_name in self.unittest_shortcuts:
                             # There are multiple unit tests with the same file name. So we cannot
                             # create a shortcut for this test name.
+                            print('*** Duplicate test file name detected. No alias has been created for it, recommend renaming:', test_file_name)
                             del self.unittest_shortcuts[test_file_name]
                             self.unittest_skipped_shortcuts.add(test_file_name)
 

--- a/build.py
+++ b/build.py
@@ -155,6 +155,8 @@ class NinjaFile(object):
         self.built_targets = set()
         self.generated_headers = set()
         self.rc_files = []
+        self.unittest_shortcuts = {}
+        self.unittest_skipped_shortcuts = set()
 
         self.init_idl_dependencies()
         self.find_build_nodes()
@@ -554,6 +556,8 @@ class NinjaFile(object):
                     print()
                     raise
 
+        self.add_unit_test_shortcuts()
+
         for build in self.builds:
             # Make everything build by scons depend on the ninja file. This makes them transitively
             # depend on all of the scons dependencies so scons gets a chance to rebuild them
@@ -570,6 +574,10 @@ class NinjaFile(object):
         if self.globalEnv.TargetOSIs('windows'):
             cmd = 'cmd /c ' + cmd
         return cmd
+
+    def add_unit_test_shortcuts(self):
+        for key in self.unittest_shortcuts:
+            self.builds.append(self.unittest_shortcuts[key])
 
     def handle_build_node(self, n):
         # TODO break this function up
@@ -834,11 +842,39 @@ class NinjaFile(object):
             if list_targets[0].startswith("@"):
                 test_name = list_targets[0]
                 test_name = '+' + test_name[1:]
+
+                # These take priority over unit test shortcut names.
+                self.unittest_skipped_shortcuts.add(test_name)
+                if test_name in self.unittest_shortcuts.keys():
+                    del self.unittest_shortcuts[test_name]
+
                 self.builds.append(dict(
                         rule='RUN_TEST',
                         outputs=test_name,
                         inputs=list_sources
                     ))
+
+                # Add shortcuts for this unit test.
+                for unit_test_source_file in \
+                        n.executor.get_all_children()[0].executor.get_all_sources():
+                    pos_last_slash = str(unit_test_source_file).rfind('/')
+                    stripped_name = str(unit_test_source_file)[pos_last_slash + 1:-2]
+
+                    if "_test" in stripped_name[len(stripped_name) - 5:]:
+                        stripped_name = '+' + stripped_name
+                        if (stripped_name not in self.unittest_shortcuts and stripped_name not
+                                in self.unittest_skipped_shortcuts):
+                            # Add a shortcut for the given unit test file name.
+                            self.unittest_shortcuts[stripped_name] = dict(
+                                rule='RUN_TEST',
+                                outputs=stripped_name,
+                                inputs=list_sources
+                            )
+                        elif stripped_name in self.unittest_shortcuts:
+                            # There are multiple unit tests with the same file name. So we cannot
+                            # create a shortcut for this test name.
+                            del self.unittest_shortcuts[stripped_name]
+                            self.unittest_skipped_shortcuts.add(stripped_name)
 
             return
 


### PR DESCRIPTION
This change makes it so that the source files for every 'env.CppUnitTest' have an executable shortcut created to the target.

For example:
```
env.CppUnitTest(
    target='db_storage_test',
    source=[
        'key_string_test.cpp',
        'kv/durable_catalog_test.cpp',
    ],
)
```

Would allow us to run 'ninja -j400 +key_string_test' or 'ninja -j400 +durable_catalog_test' to build and execute the 'db_storage_test' binary.

Some caveats:
- If there are two or more unit tests with the same name, like expression_test.cpp today, then no shortcut will be made since we don’t know which one to run.
- If a unit test shares the same name as the CppUnitTest target name in the SConscript file, we won’t create any shortcut, we’ll just run the actual target. For example, today we have something like
```
env.CppUnitTest(
   target=“map_reduce_agg_test”,
   source=[
       ‘some_test.cpp’,
       ‘map_reduce_agg_test.cpp’,
   ]
)
```
Running 'ninja -j400 +map_reduce_agg_test' will not have a shortcut to itself but running 'ninja -j400 +some_test' is still valid and will map to 'map_reduce_agg_test'.