### PR TITLE
Add mongo_test_list.py support

### DIFF
--- a/build.py
+++ b/build.py
@@ -678,6 +678,10 @@ class NinjaFile(object):
                 #TODO remove after CR merged
                 tests = strmap(sources)
 
+                if not tests and "MONGO_TEST_REGISTRY" in myEnv:
+                    # tests are now registered in a list in the Environment
+                    tests = strmap(myEnv["MONGO_TEST_REGISTRY"][ str(targets[0]) ])
+
             implicit_deps.extend([test_list_script, self.ninja_file])
             self.builds.append(dict(
                 rule='SCRIPT_RSP',


### PR DESCRIPTION
Lists of tests are now managed by https://github.com/mongodb/mongo/blob/master/site_scons/site_tools/mongo_test_list.py.

All the tests for a give *test.txt file are not in a map of lists called `MONGO_TEST_REGISTRY`