### PR TITLE
Handle len(lines) == 7

### DIFF
--- a/build.py
+++ b/build.py
@@ -780,7 +780,7 @@ class NinjaFile(object):
             # Strip out the functions from shared library builds.
             if '$SHLINK' in str(n.executor):
                 # Linux or Windows
-                assert len(lines) == 3 or len(lines) == 5
+                assert len(lines) == 3 or len(lines) == 5 or len(lines) == 7
 
                 # Run the check now. It doesn't need to happen at runtime.
                 assert lines[0] == 'SharedFlagChecker(target, source, env)'


### PR DESCRIPTION
On WSL the contents of `lines` are for me:

```
['SharedFlagChecker(target, source, env)', "${TEMPFILE('$SHLINK -o $TARGET $SHLINKFLAGS $__SHLIBVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS', 'SHLINKCOMSTR')}", 'LibSymlinksActionFunction(target, source, env)', 'touch ${TARGET}.gdb-index', '$GDB --batch-silent --quiet --nx --eval-command "save gdb-index ${TARGET.dir}" $TARGET', '$OBJCOPY --add-section .gdb_index=${TARGET}.gdb-index --set-section-flags .gdb_index=readonly ${TARGET} ${TARGET}', 'rm -f ${TARGET}.gdb-index']
```

Don't know if this is the correct solution but it fixes my local build.